### PR TITLE
typo fixes

### DIFF
--- a/_topics/config.markdown
+++ b/_topics/config.markdown
@@ -51,7 +51,7 @@ k9s:
   readOnly: false
   # This setting allows users to specify the default view, but it is not set by default.
   defaultView: ""
-  # Toggles whether k9s should exit when CTRL-C is pressed. When set to true, you will need to exist k9s via the :quit command. Default is false.
+  # Toggles whether k9s should exit when CTRL-C is pressed. When set to true, you will need to exit k9s via the :quit command. Default is false.
   noExitOnCtrlC: false
   # Default port forward host
   portForwardAddress: localhost

--- a/index.md
+++ b/index.md
@@ -21,7 +21,7 @@ K9s is a terminal based UI to interact with your Kubernetes clusters. The aim of
   - Handles both Kubernetes standard resources as well as custom resource definitions.
 
 - Cluster Metrics
-  - Tracks real-time metrics associates with resources such as pods, containers and nodes.
+  - Tracks real-time metrics associated with resources such as pods, containers and nodes.
 
 - Power Users Welcome!
   - Provides standard cluster management commands such as logs, scaling, port-forwards, restarts...


### PR DESCRIPTION
Hi,

I noticed what looks to me like a typo in the docs index and config.markdown while reading the docs (at least, the sentence reads strangely to me for index.md), thought I would file a quick PR.

Thanks for k9s!